### PR TITLE
fix target regex

### DIFF
--- a/src/fake.fs
+++ b/src/fake.fs
@@ -59,7 +59,7 @@ module FakeService =
         do loadParameters ()
         script
         |> Globals.readFileSync
-        |> fun n -> (n.toString(), "Target \"([\\w.]+)\"")
+        |> fun n -> (n.toString(), "Target \"([^\\".]+)\"")
         |> Regex.Matches
         |> Seq.cast<Match>
         |> Seq.toArray


### PR DESCRIPTION
This fixes #8 it will match all chars except `"` and `.` between the two `"` for the target name.