### PR TITLE
Allow executing targets that have spaces. Fixes #14

### DIFF
--- a/src/fake.fs
+++ b/src/fake.fs
@@ -32,7 +32,7 @@ module FakeService =
         if JS.isDefined target then
             outputChannel.clear ()
             let startedMessage = window.Globals.setStatusBarMessage "Build started"
-            let proc = Process.spawnWithNotification command linuxPrefix target outputChannel
+            let proc = Process.spawnWithNotification command linuxPrefix (sprintf "\"%s\"" target) outputChannel
             let data = {Name = (if target = "" then "Default" else target); Start = DateTime.Now; End = None; Process = proc}
             BuildList.Add data
             let cfg = workspace.Globals.getConfiguration ()


### PR DESCRIPTION
By placing the target name in double quotes, the target name will be sent correctly to the command line.