### PR TITLE
Fixed a problem #18 had.

### DIFF
--- a/src/fake.fs
+++ b/src/fake.fs
@@ -32,7 +32,8 @@ module FakeService =
         if JS.isDefined target then
             outputChannel.clear ()
             let startedMessage = window.Globals.setStatusBarMessage "Build started"
-            let proc = Process.spawnWithNotification command linuxPrefix (sprintf "\"%s\"" target) outputChannel
+            let fixSpaces s = if s |> String.exists ((=) ' ') then s |> sprintf "\"%s\"" else s
+            let proc = Process.spawnWithNotification command linuxPrefix (fixSpaces target) outputChannel
             let data = {Name = (if target = "" then "Default" else target); Start = DateTime.Now; End = None; Process = proc}
             BuildList.Add data
             let cfg = workspace.Globals.getConfiguration ()


### PR DESCRIPTION
#18 has a bug. It applies double quotes even in cases where they are not needed, something FAKE does not like.
This means that the plugin can only build targets with spaces.