### PR TITLE
Supporting Target discovery in FAKE 5

### DIFF
--- a/src/fake.fs
+++ b/src/fake.fs
@@ -60,7 +60,7 @@ module FakeService =
         do loadParameters ()
         script
         |> Globals.readFileSync
-        |> fun n -> (n.toString(), "Target \"([^\".]+)\"")
+        |> fun n -> (n.toString(), "Target(\.Create)? \"([^\".]+)\"")
         |> Regex.Matches
         |> Seq.cast<Match>
         |> Seq.toArray

--- a/src/fake.fs
+++ b/src/fake.fs
@@ -64,7 +64,7 @@ module FakeService =
         |> Regex.Matches
         |> Seq.cast<Match>
         |> Seq.toArray
-        |> Array.map(fun m -> m.Groups.[2].Value)
+        |> Array.map(fun m -> m.Groups.[if m.Groups.Count = 2 then 2 else 1].Value)
         |> Promise.lift
         |> window.Globals.showQuickPick
         |> Promise.toPromise

--- a/src/fake.fs
+++ b/src/fake.fs
@@ -64,7 +64,7 @@ module FakeService =
         |> Regex.Matches
         |> Seq.cast<Match>
         |> Seq.toArray
-        |> Array.map(fun m -> m.Groups.[1].Value)
+        |> Array.map(fun m -> m.Groups.[2].Value)
         |> Promise.lift
         |> window.Globals.showQuickPick
         |> Promise.toPromise


### PR DESCRIPTION
FAKE 5 now uses `Target.Create "Target Name"` for defining targets. I've updated the regex to have an option test for that.